### PR TITLE
feat: add weekly schedule section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,16 @@ Este repositorio contiene un sitio estático para publicar en `https://<tu-usuar
 
 ## Edición
 Puedes editar los archivos desde el navegador (icono ✏️) o pulsando `.` en el repo para abrir el editor web.
+
+## Horario semanal
+Los eventos de "Mi Horario Semanal" se editan en `assets/js/schedule.js`. Cada elemento del arreglo `events` tiene la forma:
+
+```js
+{ title: "Materia", day: 1, start: 9, end: 12 }
+```
+
+- `title`: nombre a mostrar.
+- `day`: número del día (1=Lunes, 7=Domingo).
+- `start` y `end`: horas en formato 24 h.
+
+Agrega, elimina o modifica estos objetos para actualizar tu horario sin tocar el HTML.

--- a/assets/js/schedule.js
+++ b/assets/js/schedule.js
@@ -1,0 +1,56 @@
+const events = [
+  { title: "Curso de Testing Master", day: 1, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 2, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 3, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 4, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 5, start: 9, end: 12 },
+  { title: "Álgebra práctica", day: 1, start: 13, end: 15 },
+  { title: "Álgebra práctica", day: 3, start: 13, end: 15 },
+  { title: "Álgebra teórica", day: 1, start: 15, end: 17 },
+  { title: "Álgebra teórica", day: 3, start: 15, end: 17 },
+  { title: "Física de los sistemas de partículas", day: 2, start: 14, end: 17 },
+  { title: "Física de los sistemas de partículas", day: 4, start: 14, end: 17 },
+  { title: "Análisis matemático", day: 1, start: 20, end: 22 },
+  { title: "Química básica", day: 3, start: 20, end: 22 },
+  { title: "Análisis matemático II", day: 5, start: 20, end: 22 }
+];
+
+const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"];
+
+function buildSchedule() {
+  const grid = document.getElementById('schedule');
+  if (!grid) return;
+
+  // Day headers
+  days.forEach((day, index) => {
+    const cell = document.createElement('div');
+    cell.className = 'day-header';
+    cell.textContent = day;
+    cell.style.gridColumn = index + 2;
+    cell.style.gridRow = 1;
+    grid.appendChild(cell);
+  });
+
+  // Time labels 9:00 to 22:00
+  for (let h = 9; h <= 22; h++) {
+    const label = document.createElement('div');
+    label.className = 'time-label';
+    label.textContent = `${h}:00`;
+    label.style.gridColumn = 1;
+    label.style.gridRow = h - 9 + 2;
+    grid.appendChild(label);
+  }
+
+  // Events
+  events.forEach(evt => {
+    const el = document.createElement('div');
+    el.className = 'event';
+    el.setAttribute('aria-label', `${evt.title}, ${evt.start}:00 a ${evt.end}:00`);
+    el.style.gridColumn = evt.day + 1;
+    el.style.gridRow = `${evt.start - 9 + 2} / ${evt.end - 9 + 2}`;
+    el.innerHTML = `<strong>${evt.title}</strong><span>${evt.start}–${evt.end}</span>`;
+    grid.appendChild(el);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', buildSchedule);

--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@
           <li>Próximos pasos</li>
         </ul>
       </article>
+      <article class="card" id="semana">
+        <h2>Mi Horario Semanal</h2>
+        <div class="schedule-wrapper">
+          <div class="schedule-grid" id="schedule"></div>
+        </div>
+      </article>
 
       <article class="card">
         <h2>Contacto</h2>
@@ -44,6 +50,8 @@
         <small>Actualizado el <span id="updated"></span> · Publicado con GitHub Pages</small>
       </div>
     </footer>
+
+    <script src="assets/js/schedule.js"></script>
 
     <script>
       document.getElementById('updated').textContent = new Date().toLocaleDateString('es-AR', { year:'numeric', month:'long', day:'numeric' });

--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,53 @@ body {
 
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
+
+/* Horario semanal */
+#semana {
+  scroll-margin-top: 80px;
+}
+.schedule-wrapper {
+  overflow-x: auto;
+}
+.schedule-grid {
+  display: grid;
+  grid-template-columns: 60px repeat(7, 1fr);
+  grid-template-rows: 40px repeat(13, 60px) 40px;
+  min-width: 720px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel);
+}
+.day-header {
+  text-align: center;
+  font-weight: bold;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.time-label {
+  text-align: right;
+  padding-right: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.event {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  padding: 4px;
+  margin: 2px;
+  box-shadow: 0 2px 6px rgba(0,0,0,.3);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-size: 14px;
+}
+.event span {
+  font-size: 12px;
+  opacity: .8;
+}
+@media (min-width: 768px) {
+  .schedule-wrapper {
+    overflow-x: hidden;
+  }
+}


### PR DESCRIPTION
## Summary
- add "Mi Horario Semanal" with weekly grid and events
- style schedule with responsive dark theme
- document how to edit events JSON in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7de5fc008327864d99777ea6a0e2