### PR TITLE
feat: load schedule events from Supabase

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,20 +86,14 @@
       </div>
     </footer>
 
-    <script src="assets/js/schedule.js"></script>
-<script src="assets/js/schedule.js" defer></script>
+    <script type="module" src="assets/js/schedule.js"></script>
 <script src="assets/js/plan.js" defer></script>
 <script>
-  document.getElementById('updated').textContent =
-    new Date().toLocaleDateString('es-AR', { year:'numeric', month:'long', day:'numeric' });
+  document.getElementById('updated').textContent = new Date().toLocaleDateString('es-AR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
 </script>
-
-    <script>
-      document.getElementById('updated').textContent = new Date().toLocaleDateString('es-AR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      });
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Fetch and render weekly schedule data from Supabase
- Update schedule in real time and expose helper to add new events
- Load schedule script as ES module

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab35c725e083278b22b298d0b93d35