### PR TITLE
Remove Supabase from schedule and fix plan dropdown

### DIFF
--- a/assets/js/schedule.js
+++ b/assets/js/schedule.js
@@ -1,32 +1,31 @@
-import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
-
-const SUPABASE_URL = "https://njzzuqdnigafpymgvizr.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5qenp1cWRuaWdhZnB5bWd2aXpyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYwNTE1NjQsImV4cCI6MjA3MTYyNzU2NH0.eq_o2LFRxX2tLMvXpkc-jJFuzIX_orjBFAoWWyAVqt8";
-
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const events = [
+  { title: "Curso de Testing Master", day: 1, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 2, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 3, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 4, start: 9, end: 12 },
+  { title: "Curso de Testing Master", day: 5, start: 9, end: 12 },
+  { title: "Álgebra práctica", day: 1, start: 13, end: 15 },
+  { title: "Álgebra práctica", day: 3, start: 13, end: 15 },
+  { title: "Álgebra teórica", day: 1, start: 15, end: 17 },
+  { title: "Álgebra teórica", day: 3, start: 15, end: 17 },
+  { title: "Física de los sistemas de partículas", day: 2, start: 14, end: 17 },
+  { title: "Física de los sistemas de partículas", day: 4, start: 14, end: 17 },
+  { title: "Análisis matemático", day: 1, start: 20, end: 22 },
+  { title: "Química básica", day: 3, start: 20, end: 22 },
+  { title: "Análisis matemático II", day: 5, start: 20, end: 22 }
+];
 
 const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado", "Domingo"];
-let events = [];
 
-async function fetchAndRender() {
-  const { data, error } = await supabase.from('events').select('*');
-  if (error) {
-    console.error('Error al cargar eventos', error);
-    return;
-  }
-  events = data || [];
-  buildSchedule(events);
-}
-
-function buildSchedule(events) {
-  const grid = document.getElementById('schedule');
+function buildSchedule() {
+  const grid = document.getElementById("schedule");
   if (!grid) return;
-  grid.innerHTML = '';
+  grid.innerHTML = "";
 
   // Encabezados de días
   days.forEach((day, index) => {
-    const cell = document.createElement('div');
-    cell.className = 'day-header';
+    const cell = document.createElement("div");
+    cell.className = "day-header";
     cell.textContent = day;
     cell.style.gridColumn = index + 2;
     cell.style.gridRow = 1;
@@ -35,8 +34,8 @@ function buildSchedule(events) {
 
   // Etiquetas de horas de 9:00 a 22:00
   for (let h = 9; h <= 22; h++) {
-    const label = document.createElement('div');
-    label.className = 'time-label';
+    const label = document.createElement("div");
+    label.className = "time-label";
     label.textContent = `${h}:00`;
     label.style.gridColumn = 1;
     label.style.gridRow = h - 9 + 2;
@@ -46,8 +45,8 @@ function buildSchedule(events) {
   // Cuadrícula para bordes
   for (let h = 9; h < 22; h++) {
     for (let d = 0; d < 7; d++) {
-      const slot = document.createElement('div');
-      slot.className = 'slot';
+      const slot = document.createElement("div");
+      slot.className = "slot";
       slot.style.gridColumn = d + 2;
       slot.style.gridRow = h - 9 + 2;
       grid.appendChild(slot);
@@ -56,9 +55,9 @@ function buildSchedule(events) {
 
   // Eventos
   events.forEach(evt => {
-    const el = document.createElement('div');
-    el.className = 'event';
-    el.setAttribute('aria-label', `${evt.title}, ${evt.start}:00 a ${evt.end}:00`);
+    const el = document.createElement("div");
+    el.className = "event";
+    el.setAttribute("aria-label", `${evt.title}, ${evt.start}:00 a ${evt.end}:00`);
     el.style.gridColumn = evt.day + 2;
     el.style.gridRow = `${evt.start - 9 + 2} / ${evt.end - 9 + 2}`;
     el.innerHTML = `<strong>${evt.title}</strong><span>${evt.start}–${evt.end}</span>`;
@@ -66,23 +65,4 @@ function buildSchedule(events) {
   });
 }
 
-function setupRealtime() {
-  supabase
-    .channel('public:events')
-    .on('postgres_changes', { event: '*', schema: 'public', table: 'events' }, () => {
-      fetchAndRender();
-    })
-    .subscribe();
-}
-
-window.addEvent = async function(title, day, start, end) {
-  const { error } = await supabase.from('events').insert([{ title, day, start, end }]);
-  if (error) {
-    console.error('Error al agregar evento', error);
-  }
-};
-
-document.addEventListener('DOMContentLoaded', () => {
-  fetchAndRender();
-  setupRealtime();
-});
+document.addEventListener("DOMContentLoaded", buildSchedule);

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
       </div>
     </footer>
 
-    <script type="module" src="assets/js/schedule.js"></script>
+    <script src="assets/js/schedule.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script>
       const SUPABASE_URL = "https://njzzuqdnigafpymgvizr.supabase.co";

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,9 @@ a:hover { text-decoration: underline; }
   color: inherit;
   font-size: 0.875rem;
 }
+.materia-pill select option {
+  color: #000;
+}
 .materia-pill.estado-aprobada { background: #2e7d32; color: #fff; }
 .materia-pill.estado-cursando { background: #1565c0; color: #fff; }
 .materia-pill.estado-regular { background: #ffb300; color: #000; }


### PR DESCRIPTION
## Summary
- Render weekly schedule from a static list instead of Supabase
- Ensure subject state dropdown options remain visible

## Testing
- `npm test` (fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/juanpablo24-06.github.io/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68ab4fbe60048327bc6bfc35719f2e1f