### PR TITLE
feat: add password-based login with Supabase

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,16 @@
     <main class="container">
       <section id="login-view" class="card">
         <h2>Ingresar</h2>
-        <form id="login-form">
-          <input type="email" id="email" placeholder="tu@correo.com" required />
-          <button type="submit">Enviar enlace</button>
+        <form id="viewer-form">
+          <input type="password" id="pw-viewer" placeholder="Contraseña" />
+          <button type="submit">Entrar</button>
         </form>
-        <p id="auth-msg"></p>
+        <button id="show-admin-btn" type="button">Entrar como editor</button>
+        <form id="admin-form" hidden>
+          <input type="password" id="pw-admin" placeholder="Contraseña editor" />
+          <button type="submit">Entrar</button>
+        </form>
+        <div id="auth-msg"></div>
       </section>
 
       <div id="app-view" hidden>


### PR DESCRIPTION
## Summary
- replace magic-link login with viewer/admin password forms
- load and update plan entries with realtime updates for admin account
- manage Supabase sessions and toggle read-only or editing modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a0ef1d0832793392f39269e706c