### PR TITLE
feat: redesign study route with editable pills

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,11 +1,11 @@
 // app.js - Manejo de autenticación y plan de estudios
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-// --- Constantes de Supabase (reemplaza con las tuyas) ---
+// --- Constantes de Supabase (pegar aquí las 5 credenciales) ---
 const SUPABASE_URL = 'https://njzzuqdnigafpymgvizr.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5qenp1cWRuaWdhZnB5bWd2aXpyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYwNTE1NjQsImV4cCI6MjA3MTYyNzU2NH0.eq_o2LFRxX2tLMvXpkc-jJFuzIX_orjBFAoWWyAVqt8';
 const VIEWER_EMAIL = 'viewer@fiuba.local';
-const ADMIN_EMAIL = 'juanpablo20240604@gmail.com';
+const ADMIN_EMAIL = 'Juanpablo20240604@gmail.com';
 const ADMIN_UUID = 'e6c2299b-a401-40b2-8af9-550cd0d8c2cc';
 
 // Inicializa el cliente
@@ -22,6 +22,7 @@ const states = [
 
 // Referencias y variables de estado
 const subjectElements = new Map();
+const pending = new Map(); // timers para debounce
 let planChannel = null;
 let isAdmin = false;
 
@@ -31,12 +32,23 @@ const adminForm = document.getElementById('admin-form');
 const showAdminBtn = document.getElementById('show-admin-btn');
 const authMsg = document.getElementById('auth-msg');
 const signOutBtn = document.getElementById('signout-btn');
+const toast = document.getElementById('toast');
 
 function showError(msg) {
   authMsg.textContent = msg;
 }
 function clearError() {
   authMsg.textContent = '';
+}
+
+function showToast(msg, isError = false) {
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.classList.toggle('error', isError);
+  toast.hidden = false;
+  setTimeout(() => {
+    toast.hidden = true;
+  }, 1500);
 }
 
 // Muestra/oculta vistas
@@ -51,10 +63,11 @@ function showApp() {
   signOutBtn.hidden = false;
 }
 
-// Deshabilita o habilita selects
+// Deshabilita o habilita controles de estado
 function setEditing(enable) {
-  subjectElements.forEach(({ select }) => {
-    select.disabled = !enable;
+  subjectElements.forEach(({ group, buttons }) => {
+    group.setAttribute('aria-disabled', enable ? 'false' : 'true');
+    buttons.forEach((b) => (b.disabled = !enable));
   });
 }
 
@@ -63,6 +76,7 @@ async function fetchCourses() {
   const { data, error } = await supabase
     .from('courses')
     .select('id,name,year,cuat,pos')
+    .gte('year', 2)
     .order('year')
     .order('cuat')
     .order('pos');
@@ -74,6 +88,7 @@ async function fetchCourses() {
 }
 
 async function loadPlan() {
+  renderSkeleton();
   const courses = await fetchCourses();
   renderCourses(courses);
   const { data: entries, error } = await supabase
@@ -85,15 +100,31 @@ async function loadPlan() {
     return;
   }
   (entries || []).forEach((row) => {
-    const elem = subjectElements.get(row.course_id);
-    if (!elem) return;
-    elem.select.value = row.status;
-    elem.pill.classList.remove(...states.map((s) => `estado-${s.value}`));
-    elem.pill.classList.add(`estado-${row.status}`);
+    applyStatus(row.course_id, row.status);
   });
 }
 
-// Renderiza cursos y sus selects
+function applyStatus(courseId, status) {
+  const elem = subjectElements.get(courseId);
+  if (!elem) return;
+  elem.buttons.forEach((b) => {
+    const checked = b.dataset.value === status;
+    b.setAttribute('aria-checked', checked ? 'true' : 'false');
+  });
+}
+
+function renderSkeleton() {
+  const container = document.getElementById('ruta-estudios');
+  if (!container) return;
+  container.innerHTML = '';
+  for (let i = 0; i < 5; i++) {
+    const s = document.createElement('div');
+    s.className = 'skeleton';
+    container.appendChild(s);
+  }
+}
+
+// Agrupa cursos por año y cuatrimestre y dibuja las tarjetas
 function renderCourses(courses) {
   const container = document.getElementById('ruta-estudios');
   if (!container) return;
@@ -107,73 +138,100 @@ function renderCourses(courses) {
     grouped[c.year][c.cuat].push(c);
   });
 
+  const cuatLabels = {
+    3: 'Tercer',
+    4: 'Cuarto',
+    5: 'Quinto',
+    6: 'Sexto',
+    7: 'Séptimo',
+    8: 'Octavo',
+    9: 'Noveno',
+    10: 'Décimo',
+    11: 'Undécimo'
+  };
+
   Object.keys(grouped)
     .sort((a, b) => a - b)
     .forEach((year) => {
+      const yearPanel = document.createElement('div');
+      yearPanel.className = 'year-panel';
+      const h3 = document.createElement('h3');
+      h3.textContent = `Año ${year}`;
+      yearPanel.appendChild(h3);
+      const timeline = document.createElement('div');
+      timeline.className = 'timeline';
+      yearPanel.appendChild(timeline);
+      const cuatGrid = document.createElement('div');
+      cuatGrid.className = 'cuat-grid';
+
       const yearData = grouped[year];
-      const details = document.createElement('details');
-      details.className = 'plan-year';
-      details.open = true;
-      const summary = document.createElement('summary');
-      summary.className = 'year-header';
-      summary.textContent = `Año ${year}`;
-      const steps = document.createElement('div');
-      steps.className = 'year-steps';
-      const cuats = Object.keys(yearData).sort((a, b) => a - b);
-      cuats.forEach(() => {
-        const step = document.createElement('span');
-        step.className = 'step';
-        steps.appendChild(step);
-      });
-      summary.appendChild(steps);
-      details.appendChild(summary);
-      const grid = document.createElement('div');
-      grid.className = 'cuatimestres';
-      cuats.forEach((cuat) => {
-        const col = document.createElement('div');
-        col.className = 'cuatrimestre';
-        const h4 = document.createElement('h4');
-        h4.textContent = `Cuatr. ${cuat}`;
-        col.appendChild(h4);
-        yearData[cuat].forEach((course) => {
-          const pill = document.createElement('div');
-          pill.className = 'materia-pill estado-futura';
-          pill.dataset.courseId = course.id;
-          const span = document.createElement('span');
-          span.textContent = course.name;
-          pill.appendChild(span);
-          const select = document.createElement('select');
-          select.dataset.courseId = course.id;
-          states.forEach((st) => {
-            const opt = document.createElement('option');
-            opt.value = st.value;
-            opt.textContent = st.label;
-            select.appendChild(opt);
+      Object.keys(yearData)
+        .sort((a, b) => a - b)
+        .forEach((cuat) => {
+          const cuatPanel = document.createElement('div');
+          cuatPanel.className = 'cuat-panel';
+          const h4 = document.createElement('h4');
+          h4.textContent = cuatLabels[cuat] || `Cuat. ${cuat}`;
+          cuatPanel.appendChild(h4);
+
+          yearData[cuat].forEach((course) => {
+            const card = document.createElement('div');
+            card.className = 'subject-card';
+            const name = document.createElement('span');
+            name.textContent = course.name;
+            card.appendChild(name);
+
+            const group = document.createElement('div');
+            group.className = 'estado-pills';
+            group.setAttribute('role', 'radiogroup');
+
+            const buttons = [];
+            states.forEach((s) => {
+              const btn = document.createElement('button');
+              btn.type = 'button';
+              btn.textContent = s.label;
+              btn.className = s.value;
+              btn.dataset.value = s.value;
+              btn.setAttribute('role', 'radio');
+              btn.setAttribute('aria-checked', 'false');
+              btn.addEventListener('click', () => {
+                if (!isAdmin) return;
+                applyStatus(course.id, s.value);
+                debounceSave(course.id, s.value);
+              });
+              group.appendChild(btn);
+              buttons.push(btn);
+            });
+
+            card.appendChild(group);
+            cuatPanel.appendChild(card);
+            subjectElements.set(course.id, { card, group, buttons });
+            applyStatus(course.id, 'futura');
           });
-          select.value = 'futura';
-          select.disabled = !isAdmin;
-          select.addEventListener('change', async () => {
-            const status = select.value;
-            pill.classList.remove(...states.map((s) => `estado-${s.value}`));
-            pill.classList.add(`estado-${status}`);
-            try {
-              await upsertPlanEntry(course.id, status);
-            } catch (err) {
-              console.error('DB:', err);
-            }
-          });
-          pill.appendChild(select);
-          col.appendChild(pill);
-          subjectElements.set(course.id, { pill, select });
+
+          cuatGrid.appendChild(cuatPanel);
         });
-        grid.appendChild(col);
-      });
-      details.appendChild(grid);
-      container.appendChild(details);
+
+      yearPanel.appendChild(cuatGrid);
+      container.appendChild(yearPanel);
     });
 }
 
-// Inserta/actualiza el plan
+function debounceSave(courseId, status) {
+  clearTimeout(pending.get(courseId));
+  const t = setTimeout(async () => {
+    try {
+      await upsertPlanEntry(courseId, status);
+      showToast('Guardado ✓');
+    } catch (err) {
+      console.error('DB:', err);
+      showToast('Error al guardar', true);
+    }
+  }, 250);
+  pending.set(courseId, t);
+}
+
+// Inserta/actualiza el plan en plan_entries usando upsert
 async function upsertPlanEntry(courseId, status) {
   const { error } = await supabase
     .from('plan_entries')
@@ -197,11 +255,7 @@ function subscribeRealtime() {
         if (data.user_id !== ADMIN_UUID) return;
         const courseId = data.course_id;
         const status = payload.eventType === 'DELETE' ? 'futura' : data.status;
-        const elem = subjectElements.get(courseId);
-        if (!elem) return;
-        elem.select.value = status;
-        elem.pill.classList.remove(...states.map((s) => `estado-${s.value}`));
-        elem.pill.classList.add(`estado-${status}`);
+        applyStatus(courseId, status);
         console.log('RT:', payload.eventType, courseId, status);
       }
     )

--- a/index.html
+++ b/index.html
@@ -84,28 +84,29 @@
           </div>
         </section>
 
-        <section id="ruta" class="card">
-          <h2>¿Cuál es mi ruta de estudios?</h2>
-          <p class="legend">✓ Aprobada · ■ Cursando · ● Regular con final · ○ Futura · ! A recursar</p>
-          <div id="ruta-estudios"></div>
-        </section>
-      </div>
-    </main>
+          <section id="ruta" class="card">
+            <h2>¿Cuál es mi ruta de estudios?</h2>
+            <p class="legend">✓ Aprobada · ■ Cursando · ● Regular con final · ○ Futura · ! A recursar</p>
+            <div id="ruta-estudios"></div>
+          </section>
+        </div>
+      </main>
 
-    <footer class="site-footer">
+      <footer class="site-footer">
       <div class="container">
         <small>Última actualización: <span id="updated"></span></small>
       </div>
     </footer>
 
     <script src="assets/js/schedule.js"></script>
-    <script type="module" src="assets/js/app.js"></script>
-<script>
-  document.getElementById('updated').textContent = new Date().toLocaleDateString('es-AR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  });
-</script>
-  </body>
-</html>
+      <script type="module" src="assets/js/app.js"></script>
+      <div id="toast" class="toast" hidden></div>
+ <script>
+    document.getElementById('updated').textContent = new Date().toLocaleDateString('es-AR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  </script>
+    </body>
+  </html>

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,11 @@
   --panel: #111318;
   --text: #e5e7eb;
   --muted: #9ca3af;
-  --accent: #4f46e5;
+  --ok: #16a34a;
+  --info: #2563eb;
+  --warn: #facc15;
+  --err: #dc2626;
+  --accent: var(--info);
   --border: #1f2430;
 }
 
@@ -121,101 +125,111 @@ a:hover { text-decoration: underline; }
 #ruta-estudios {
   margin-top: 16px;
 }
-.plan-year {
-  margin-bottom: 24px;
+.year-panel {
+  margin-bottom: 32px;
+  padding: 16px;
+  background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 8px;
-  overflow: hidden;
 }
-.plan-year > summary {
-  list-style: none;
-  padding: 12px 16px;
-  background: #1a1d24;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.year-panel h3 {
+  margin: 0 0 12px;
+  font-size: 1.25rem;
 }
-.plan-year > summary::-webkit-details-marker { display: none; }
-.year-steps {
-  display: flex;
-  flex: 1;
-  margin-left: 16px;
-  gap: 8px;
-}
-.year-steps .step {
-  position: relative;
-  flex: 1;
-  background: var(--border);
+.timeline {
   height: 4px;
+  background: var(--border);
+  margin-bottom: 16px;
   border-radius: 2px;
 }
-.year-steps .step::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--muted);
-}
-.cuatimestres {
+.cuat-grid {
   display: flex;
   gap: 16px;
-  padding: 16px;
+  flex-wrap: wrap;
 }
-.cuatrimestre {
+.cuat-panel {
   flex: 1;
+  min-width: 220px;
 }
-.cuatrimestre h4 {
+.cuat-panel h4 {
   margin-top: 0;
 }
-.materia-pill {
+.subject-card {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 4px 8px;
-  border-radius: 9999px;
-  background: #1f2430;
-  box-shadow: 0 2px 4px rgba(0,0,0,.3);
+  align-items: center;
+  padding: 6px 8px;
   margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
 }
-.materia-pill select {
+.estado-pills {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+.estado-pills[aria-disabled="true"] {
+  opacity: .6;
+  cursor: not-allowed;
+}
+.estado-pills button {
+  flex: 1;
+  padding: 4px 6px;
   background: transparent;
   border: none;
-  color: inherit;
-  font-size: 0.875rem;
-}
-.materia-pill select option {
-  color: #000;
-}
-.materia-pill.estado-aprobada { background: #2e7d32; color: #fff; }
-.materia-pill.estado-cursando { background: #1565c0; color: #fff; }
-.materia-pill.estado-regular { background: #ffb300; color: #000; }
-.materia-pill.estado-futura { background: #424242; color: #fff; }
-.materia-pill.estado-recursar { background: #c62828; color: #fff; }
-#ruta-estudios button {
-  margin-top: 16px;
-  padding: 8px 16px;
-  border: none;
-  border-radius: 4px;
-  background: #333;
   color: var(--text);
+  font-size: 12px;
   cursor: pointer;
 }
-#ruta-estudios button:hover {
-  background: #444;
+.estado-pills button:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: 2px;
 }
+.estado-pills button[aria-checked="true"].aprobada { background: var(--ok); }
+.estado-pills button[aria-checked="true"].cursando { background: var(--info); }
+.estado-pills button[aria-checked="true"].regular { background: var(--warn); color: #000; }
+.estado-pills button[aria-checked="true"].futura { background: transparent; }
+.estado-pills button[aria-checked="true"].recursar { background: var(--err); }
+
+/* Skeleton loaders */
+.skeleton {
+  background: var(--border);
+  height: 24px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: .4; }
+  50% { opacity: 1; }
+}
+
+/* Toasts */
+.toast {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 8px 16px;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,.3);
+  color: var(--text);
+  z-index: 1000;
+}
+.toast.error {
+  background: var(--err);
+}
+
 @media (max-width: 600px) {
-  .plan-year > summary::-webkit-details-marker { display: initial; }
-  .cuatimestres {
+  .cuat-grid {
     flex-direction: column;
   }
 }
 
-/* Login y toasts */
+/* Login */
 #login-view form {
   display: flex;
   gap: 8px;
@@ -223,16 +237,4 @@ a:hover { text-decoration: underline; }
 #login-view input {
   flex: 1;
   padding: 8px;
-}
-.toast {
-  position: fixed;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #333;
-  color: var(--text);
-  padding: 8px 16px;
-  border-radius: 4px;
-  box-shadow: 0 2px 6px rgba(0,0,0,.3);
-  z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- redesign study plan section using dark theme panels and segmented status pills
- add debounced upsert with toasts and realtime updates
- include skeleton loaders and filter courses from second year onward

## Testing
- `node --check assets/js/app.js`

## Checklist
- [ ] Viewer ve y no puede editar.
- [ ] Admin sí puede editar y guarda con upsert.
- [ ] Cambios se reflejan en otra pestaña (realtime).
- [ ] Se muestran solo cursos del segundo ciclo (años 2→último).
- [ ] Sin errores en consola.
- [ ] Responsive y accesible.


------
https://chatgpt.com/codex/tasks/task_e_68ab93381b448327a91a5f0cf4b2b092